### PR TITLE
Arrange squad cards responsively into columns

### DIFF
--- a/src/pages/Squad.tsx
+++ b/src/pages/Squad.tsx
@@ -669,7 +669,7 @@ const Squad = () => {
       {viewMode === 'card' && (
         <div className="">
           {isLoading ? (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-4">
               {Array.from({ length: 6 }).map((_,i)=> (
                 <div key={i} className="rounded-2xl border p-4">
                   <div className="flex items-center gap-3">
@@ -684,7 +684,7 @@ const Squad = () => {
             </div>
           ) : (
             <>
-              <div className="space-y-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                 {filteredAndSortedPlayers.map((p)=> {
                   const role = rolesByCode[(p as any).role_code || '']
                   const matchPres = p.matchPresences || 0


### PR DESCRIPTION
Implement responsive multi-column grid for player cards on the Squad page to display 3 cards per row on iPad Pro and more on larger screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec76f343-07ec-4ca9-b9c7-2286f5f94f3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec76f343-07ec-4ca9-b9c7-2286f5f94f3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

